### PR TITLE
fix: Update Cloud Run health check parameters for improved reliability

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -194,10 +194,10 @@ resource "google_cloud_run_service" "backend_api" {
             path = "/health"
             port = 8080
           }
-          initial_delay_seconds = 10
-          timeout_seconds       = 5
-          period_seconds        = 10
-          failure_threshold     = 3
+          initial_delay_seconds = 30
+          timeout_seconds       = 10
+          period_seconds        = 15
+          failure_threshold     = 5
         }
 
         liveness_probe {


### PR DESCRIPTION
- Increased initial delay, timeout, period, and failure threshold for the liveness probe in the Terraform configuration of the backend API to enhance service stability and responsiveness.