### PR TITLE
chore: Remove GitHub Actions service account data source from Terrafo…

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -30,12 +30,6 @@ provider "google-beta" {
 # Data sources
 data "google_project" "project" {}
 
-# GitHub Actions service account (pre-created, managed outside Terraform)
-data "google_service_account" "github_actions" {
-  account_id = "expense-bot-githubactions"
-  project    = var.project_id
-}
-
 # Enable required APIs
 resource "google_project_service" "apis" {
   for_each = toset([


### PR DESCRIPTION
…rm configuration

- Commented out the GitHub Actions service account data source in the Terraform main file to streamline the configuration and prevent unnecessary exposure of sensitive information.