### PR TITLE
fix: Cloud Run revision name must include service name prefix

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -118,7 +118,8 @@ resource "google_cloud_run_service" "backend_api" {
 
   template {
     metadata {
-      name = "${var.environment}-${substr(var.backend_image_tag, 0, 8)}"
+      # Revision name must be prefixed with service name
+      name = "expense-bot-backend-${var.environment}-${substr(var.backend_image_tag, 0, 8)}"
 
       annotations = {
         "autoscaling.knative.dev/minScale"         = var.environment == "production" ? "2" : "0"


### PR DESCRIPTION
The revision name must be prefixed with the service name followed by a dash. Changed from: {environment}-{sha}
To: expense-bot-backend-{environment}-{sha}

This fixes the Cloud Run deployment error.

🤖 Generated with [Claude Code](https://claude.ai/code)